### PR TITLE
added make targets for generating certs and keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps all
+.PHONY: deps all certs keys
 
 all: deps
 	beamer make
@@ -6,5 +6,8 @@ all: deps
 deps:
 	beamer deps
 
+certs:
+	mkdir -p certs && mkcert -cert-file certs/new-cert.pem -key-file certs/new-key.pem mesgd.example.com localhost 127.0.0.1 ::1
 
-
+keys:
+	mkdir -p keys && ssh-keygen -t rsa -f keys/new-key && mv keys/new-key keys/new-key.priv


### PR DESCRIPTION
mkcert may not be the only way and the hostname and local IP addresses may not be the only options but this seems handy enough to include even if for no other reason than it suggests what one might do to change things